### PR TITLE
fixing the routing back to the splash screen bug

### DIFF
--- a/lib/src/pages/splash.dart
+++ b/lib/src/pages/splash.dart
@@ -21,6 +21,8 @@ class SplashScreen extends StatelessWidget {
             builder: (context) => isLoggedIn ? const HomePage(title: 'Help a Paw') : const LoginPage(),
             settings: RouteSettings(name: isLoggedIn ? global.homeRoute : global.loginRoute)),
       );
+       // Remove all the screens from the stack until the first screen (SplashScreen)
+      Navigator.of(context).popUntil((route) => route.isFirst);
     });
 
     return Scaffold(


### PR DESCRIPTION
This pull request adds a fix for the bug that causes users to get stuck on the splash screen by adding a new code snippet that removes all the screens from the stack until the first screen, which is the SplashScreen.

The issue was caused by the user being able to press the AppBar "back" button or the phone's native "back" button and navigate back to the SplashScreen. This behavior can be prevented by removing all the screens from the stack until the first screen, which will ensure that the user cannot navigate back to the SplashScreen.

This fix improves the user experience by ensuring that users cannot accidentally navigate back to the SplashScreen and get stuck in a loop. I have tested this fix thoroughly and it works as expected.

Thank you for considering this pull request.